### PR TITLE
Add docker smoketest. Test on python 3.6, 3.7 and 3.8

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,6 @@ jobs:
       with:
         python-version: 3.7
     - name: Generate coverage report
-      uses: 'docker'
       run: |
         pip install .[test]
         pytest --cov=./ --cov-report=xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,8 +19,9 @@ jobs:
       with:
         python-version: 3.7
     - name: Generate coverage report
+      uses: 'docker'
       run: |
-        pip install  -r requirements.txt -r requirements-dev.txt
+        pip install .[test]
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov  
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Coverage
+name: Test
 
 on:
   push:
@@ -18,10 +18,8 @@ jobs:
       uses: actions/setup-python@master
       with:
         python-version: 3.7
-    - name: Generate coverage report
-      run: |
-        pip install .[test]
-        pytest --cov=./ --cov-report=xml
+    - name: Run tests
+      run: python setup.py test --addopts="--cov=nbexchange --cov-report=xml"
     - name: Upload coverage to Codecov  
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,16 @@ on:
 
 jobs:
   run:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix: 
-        os: [ubuntu-latest, macos-latest]
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@master
-    - name: Setup Python  
+    - name: Setup Python ${{ matrix.python-version }} 
       uses: actions/setup-python@master
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - name: Run tests
       run: python setup.py test --addopts="--cov=nbexchange --cov-report=xml"
     - name: Upload coverage to Codecov  

--- a/nbexchange/tests/conftest.py
+++ b/nbexchange/tests/conftest.py
@@ -84,13 +84,7 @@ def db():
     _db.commit()
     return _db
 
+
 # Docker images
-nbexchange_image = build(
-    path="."
-)
-container = container(
-    image='{nbexchange_image.id}',
-    ports={
-        '9000/tcp': None,
-    },
-)
+nbexchange_image = build(path=".")
+container = container(image="{nbexchange_image.id}", ports={"9000/tcp": None})

--- a/nbexchange/tests/conftest.py
+++ b/nbexchange/tests/conftest.py
@@ -6,6 +6,7 @@ import logging
 from getpass import getuser
 from tornado import ioloop
 from traitlets.config.loader import PyFileConfigLoader
+from pytest_docker_tools import build, container
 
 import nbexchange.models.users
 from nbexchange.database import Session
@@ -82,3 +83,14 @@ def db():
     _db.add(user)
     _db.commit()
     return _db
+
+# Docker images
+nbexchange_image = build(
+    path="."
+)
+container = container(
+    image='{nbexchange_image.id}',
+    ports={
+        '9000/tcp': None,
+    },
+)

--- a/nbexchange/tests/test_smoketest.py
+++ b/nbexchange/tests/test_smoketest.py
@@ -1,5 +1,6 @@
 import socket
 
+
 def test_smoketest_nbexchange(container):
     sock = socket.socket()
-    sock.connect(('127.0.0.1', container.ports['9000/tcp'][0]))
+    sock.connect(("127.0.0.1", container.ports["9000/tcp"][0]))

--- a/nbexchange/tests/test_smoketest.py
+++ b/nbexchange/tests/test_smoketest.py
@@ -1,0 +1,5 @@
+import socket
+
+def test_smoketest_nbexchange(container):
+    sock = socket.socket()
+    sock.connect(('127.0.0.1', container.ports['9000/tcp'][0]))

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ TESTING = [
     "pytest",
     "pytest-cov",
     "pytest-tornado",
+    "pytest-docker-tools",
     "beautifulsoup4",
     "html5lib",
     "psycopg2-binary",


### PR DESCRIPTION
This adds a test that builds the Docker container, tries to run it
and sees whether it can establish a connection to port 9000.
This test should prevent us from breaking the Docker build (again).

It also improves the GitHub action for consistent dependencies (we were mixing requirements.txt and setup.py dependencies) and adds a matrix for testing against Python 3.6, 3.7 and 3.8