### PR TITLE
Remove spammy log message

### DIFF
--- a/nbexchange/handlers/pages.py
+++ b/nbexchange/handlers/pages.py
@@ -7,5 +7,4 @@ class HomeHandler(BaseHandler):
     urls = ["/"]
 
     def get(self):
-        self.log.info(f"NbExchange {__version__}")
         self.finish(f"NbExchange {__version__}")


### PR DESCRIPTION
This message constantly appears in the logs and adds nothing useful.
Every liveness probe causes this to be logged.