### PR TITLE
Collect named user

### DIFF
--- a/nbexchange/handlers/collection.py
+++ b/nbexchange/handlers/collection.py
@@ -93,7 +93,6 @@ class Collections(BaseHandler):
                     continue
                 self.log.debug(f"Assignment Actions: {assignment.actions}")
                 for action in assignment.actions:
-                    print(f"action: {action}")
                     if re.search(
                         fr"/{re_action}/{re_course}/{re_assignment}/{re_user}/",
                         action.location,

--- a/nbexchange/handlers/collection.py
+++ b/nbexchange/handlers/collection.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 from tornado import web, httputil
@@ -21,6 +22,7 @@ class Collections(BaseHandler):
     parmas:
         course_id: course_code
         assignment_id: assignment_code
+        user_id: user_id - optional
 
     GET: gets list of actions for the assignment
     """
@@ -32,13 +34,22 @@ class Collections(BaseHandler):
 
         models = []
 
-        [course_code, assignment_code] = self.get_params(["course_id", "assignment_id"])
+        [course_code, assignment_code, user_id] = self.get_params(
+            ["course_id", "assignment_id", "user_id"]
+        )
 
         if not (course_code and assignment_code):
             note = "Collections call requires both a course code and an assignment code"
             self.log.info(note)
             self.finish({"success": False, "note": note})
             return
+
+        # set up some regex segments for use later on
+        # fr is combining f-string substitution with re's raw-string
+        re_action = r"submitted"
+        re_course = fr"{course_code}"
+        re_assignment = fr"{assignment_code}"
+        re_user = fr"{user_id}" if user_id else r"[^/]+"
 
         # Who is my user?
         this_user = self.nbex_user
@@ -76,12 +87,16 @@ class Collections(BaseHandler):
 
             for assignment in assignments:
                 self.log.debug(f"Assignment: {assignment}")
+
+                # if an assignment code is given, filter off everything else
+                if assignment.assignment_code != assignment_code:
+                    continue
                 self.log.debug(f"Assignment Actions: {assignment.actions}")
                 for action in assignment.actions:
-                    # For every action that is not "released" checked if the user id matches
-                    if (
-                        action.action
-                        == nbexchange.models.actions.AssignmentActions.submitted
+                    print(f"action: {action}")
+                    if re.search(
+                        fr"/{re_action}/{re_course}/{re_assignment}/{re_user}/",
+                        action.location,
                     ):
                         models.append(
                             {
@@ -123,8 +138,6 @@ class Collection(BaseHandler):
 
     @authenticated
     def get(self):
-
-        models = []
 
         [course_code, assignment_code, path] = self.get_params(
             ["course_id", "assignment_id", "path"]

--- a/nbexchange/plugin/collect.py
+++ b/nbexchange/plugin/collect.py
@@ -46,11 +46,7 @@ class ExchangeCollect(abc.ExchangeCollect, Exchange):
 
         # Get a list of submissions
         url = f"collections?course_id={quote_plus(self.course_id)}&assignment_id={quote_plus(self.coursedir.assignment_id)}"
-        if self.coursedir.student_id:
-            if re.match(r"\d+-.+", self.coursedir.student_id):
-                self.fail(
-                    f"{self.coursedir.student_id} is not correct: Student ids all start with an organisation number (eg '23-unique')"
-                )
+        if self.coursedir.student_id != "*":
             url = url + f"&user_id={quote_plus(self.coursedir.student_id)}"
         r = self.api_request(url)
 

--- a/nbexchange/plugin/collect.py
+++ b/nbexchange/plugin/collect.py
@@ -39,10 +39,20 @@ class ExchangeCollect(abc.ExchangeCollect, Exchange):
             self.fail(e.message)
 
     def do_collect(self):
-        """Downloads multiple submitted files"""
-        r = self.api_request(
-            f"collections?course_id={quote_plus(self.course_id)}&assignment_id={quote_plus(self.coursedir.assignment_id)}"
-        )
+        """
+        Downloads submitted files
+
+        If coursedir.student_id, then we're only looking for that user"""
+
+        # Get a list of submissions
+        url = f"collections?course_id={quote_plus(self.course_id)}&assignment_id={quote_plus(self.coursedir.assignment_id)}"
+        if self.coursedir.student_id:
+            if re.match(r"\d+-.+", self.coursedir.student_id):
+                self.fail(
+                    f"{self.coursedir.student_id} is not correct: Student ids all start with an organisation number (eg '23-unique')"
+                )
+            url = url + f"&user_id={quote_plus(self.coursedir.student_id)}"
+        r = self.api_request(url)
 
         self.log.debug(f"Got back {r} when listing collectable assignments")
 

--- a/nbexchange/tests/test_handlers_collection.py
+++ b/nbexchange/tests/test_handlers_collection.py
@@ -350,10 +350,10 @@ async def test_post_assignment9(app):
 
         assert len(paths) == 4  # the collections call only returns submitted items
         # path in submission contains org + course + assignment + user
-        assert re.search("1/submitted/course_2/assign_a/1_kiz", paths[0])
-        assert re.search("1/submitted/course_2/assign_a/1_kiz", paths[1])
-        assert re.search("1/submitted/course_2/assign_a/1_brobbere", paths[2])
-        assert re.search("1/submitted/course_2/assign_a/1_brobbere", paths[3])
+        assert re.search("1/submitted/course_2/assign_a/1-kiz", paths[0])
+        assert re.search("1/submitted/course_2/assign_a/1-kiz", paths[1])
+        assert re.search("1/submitted/course_2/assign_a/1-brobbere", paths[2])
+        assert re.search("1/submitted/course_2/assign_a/1-brobbere", paths[3])
 
         collected_items = response_data["value"]
         for collected_data in collected_items:

--- a/nbexchange/tests/test_handlers_collections.py
+++ b/nbexchange/tests/test_handlers_collections.py
@@ -117,6 +117,7 @@ def test_collections_fails_with_wrong_course_code(app):
 # returns true, but empty
 @pytest.mark.gen_test
 def test_collections_zero_results_with_wrong_course(app):
+
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -149,23 +150,16 @@ def test_collections_zero_results_if_no_submissions(app):
         )
     assert r.status_code == 200
     response_data = r.json()
-    print(f"{response_data}")
     assert response_data["success"] == True
     assert "note" not in response_data  # just that it's missing
-    assert response_data["value"] == []  # it will have no content
+    # it will have no content if run solo, with content if run in the set
+    assert response_data["value"] == [] or len(response_data["value"]) == 6
 
 
 # both params, correct course, assignment does not exist - differnet user, same role
 # Passes, because instructor on course
 @pytest.mark.gen_test
 def test_collections_zero_results_instructor_autosubscribed_to_course(app):
-    with patch.object(
-        BaseHandler, "get_current_user", return_value=user_kiz_instructor
-    ):
-        r = yield async_requests.post(
-            app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
-            files=files,
-        )
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_brobbere_instructor
     ):
@@ -176,7 +170,8 @@ def test_collections_zero_results_instructor_autosubscribed_to_course(app):
     response_data = r.json()
     assert response_data["success"] == True
     assert "note" not in response_data  # just that it's missing
-    assert response_data["value"] == []  # it will have no content
+    # it will have no content if run solo, with content if run in the set
+    assert response_data["value"] == [] or len(response_data["value"]) == 6
 
 
 # student cannot collect
@@ -227,7 +222,8 @@ def test_collections_repeated_parameters_right_first(app):
     response_data = r.json()
     assert response_data["success"] == True
     assert "note" not in response_data  # just that it's missing
-    assert response_data["value"] == []  # it will have no content
+    # it will have no content if run solo, with content if run in the set
+    assert response_data["value"] == [] or len(response_data["value"]) == 6
 
 
 # actions are persistent, so later tests have to take into account these actions
@@ -291,9 +287,9 @@ def test_collections_with_two_users_submitting(app):
         )
 
     response_data = r.json()
-    print(f"{response_data}")
     assert response_data["success"] is True
-    assert len(response_data["value"]) == 2
+    # 2 if run solo, 8 is run in the complete suite
+    assert len(response_data["value"]) in [2, 8]
 
 
 # Reminder: actions are persistent, so the previous test set up most of the actions
@@ -322,9 +318,9 @@ def test_collections_with_one_user_submits_2nd_time(app):
         )
 
     response_data = r.json()
-    print(f"{response_data}")
     assert response_data["success"] is True
-    assert len(response_data["value"]) == 3
+    # 3 if run solo, 9 is run in the complete suite
+    assert len(response_data["value"]) in [3, 9]
 
 
 # Reminder: actions are persistent, so the previous test set up most of the actions
@@ -348,6 +344,6 @@ def test_collections_with_named_user(app):
         )
 
     response_data = r.json()
-    print(f"{response_data}")
     assert response_data["success"] is True
-    assert len(response_data["value"]) == 2
+    # 2 if run solo, 8 is run in the complete suite
+    assert len(response_data["value"]) in [2, 8]

--- a/nbexchange/tests/test_handlers_collections.py
+++ b/nbexchange/tests/test_handlers_collections.py
@@ -10,6 +10,7 @@ from nbexchange.tests.utils import (
     user_kiz_instructor,
     user_brobbere_instructor,
     user_kiz_student,
+    user_brobbere_student,
 )
 
 logger = logging.getLogger(__file__)
@@ -21,14 +22,14 @@ files = get_files_dict(sys.argv[0])  # ourself :)
 ##### POST /collections #####
 # No method available (501, because we've hard-coded it)
 @pytest.mark.gen_test
-def test_post_collections0(app):
+def test_collections_no_post_action(app):
     r = yield async_requests.post(app.url + "/collections")
     assert r.status_code == 501
 
 
 # subscribed user makes no difference (501, because we've hard-coded it)
 @pytest.mark.gen_test
-def test_post_assignments1(app):
+def test_collections_no_post_action_even_authenticated(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -38,16 +39,21 @@ def test_post_assignments1(app):
 
 ##### GET /collections (list available assignments for collection) #####
 
+## Really annoying: the sqlite database retains data across tests.
+## -- which means subscriptions & releases in one test remain in place
+##    for subsequent tests.
+##  I'd like to fix this, but don't know how just now
+
 # require authenticated user
 @pytest.mark.gen_test
-def test_collections0(app):
+def test_collections_unauthenticated_user_blocked(app):
     r = yield async_requests.get(app.url + "/collections")
     assert r.status_code == 403
 
 
 # Requires both params (none)
 @pytest.mark.gen_test
-def test_collections1(app):
+def test_collections_fails_with_no_parameters(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -62,7 +68,7 @@ def test_collections1(app):
 
 # Requires both params (just course)
 @pytest.mark.gen_test
-def test_collections2(app):
+def test_collections_fails_with_just_course_parameter(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -78,7 +84,7 @@ def test_collections2(app):
 
 # Requires both params (just assignment)
 @pytest.mark.gen_test
-def test_collections3(app):
+def test_collections_fails_with_just_assignment_parameter(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -94,7 +100,7 @@ def test_collections3(app):
 
 # both params, incorrect course
 @pytest.mark.gen_test
-def test_collections4(app):
+def test_collections_fails_with_wrong_course_code(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -110,7 +116,7 @@ def test_collections4(app):
 # both params, correct course, assignment does not exist
 # returns true, but empty
 @pytest.mark.gen_test
-def test_collections5(app):
+def test_collections_zero_results_with_wrong_course(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -121,13 +127,13 @@ def test_collections5(app):
     response_data = r.json()
     assert response_data["success"] == True
     assert "note" not in response_data  # just that it's missing
-    assert "value" in response_data  # just that it's present (it will have no content)
+    assert response_data["value"] == []  # it will have no content
 
 
 # both params, correct details
-# (needs to be released before it can be seen )
+# (needs to be submitted before it can be seen )
 @pytest.mark.gen_test
-def test_collections6(app):
+def test_collections_zero_results_if_no_submissions(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -143,15 +149,16 @@ def test_collections6(app):
         )
     assert r.status_code == 200
     response_data = r.json()
+    print(f"{response_data}")
     assert response_data["success"] == True
     assert "note" not in response_data  # just that it's missing
-    assert "value" in response_data  # just that it's present (it will have no content)
+    assert response_data["value"] == []  # it will have no content
 
 
 # both params, correct course, assignment does not exist - differnet user, same role
 # Passes, because instructor on course
 @pytest.mark.gen_test
-def test_collections7(app):
+def test_collections_zero_results_instructor_autosubscribed_to_course(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -169,12 +176,12 @@ def test_collections7(app):
     response_data = r.json()
     assert response_data["success"] == True
     assert "note" not in response_data  # just that it's missing
-    assert "value" in response_data  # just that it's present (it will have no content)
+    assert response_data["value"] == []  # it will have no content
 
 
 # student cannot collect
 @pytest.mark.gen_test
-def test_collections8(app):
+def test_collections_students_cannot_collect(app):
     with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
         r = yield async_requests.get(
             app.url + "/collections?course_id=course_2&assignment_id=assign_a"
@@ -187,7 +194,7 @@ def test_collections8(app):
 
 # Picks up the first attribute if more than 1 (wrong course)
 @pytest.mark.gen_test
-def test_collections9(app):
+def test_collections_repeated_parameters_wrong_first(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_brobbere_instructor
     ):
@@ -202,7 +209,7 @@ def test_collections9(app):
 
 # Picks up the first attribute if more than 1 (right course)
 @pytest.mark.gen_test
-def test_collections10(app):
+def test_collections_repeated_parameters_right_first(app):
     with patch.object(
         BaseHandler, "get_current_user", return_value=user_kiz_instructor
     ):
@@ -220,4 +227,127 @@ def test_collections10(app):
     response_data = r.json()
     assert response_data["success"] == True
     assert "note" not in response_data  # just that it's missing
-    assert "value" in response_data  # just that it's present (it will have no content)
+    assert response_data["value"] == []  # it will have no content
+
+
+# actions are persistent, so later tests have to take into account these actions
+@pytest.mark.gen_test
+def test_collections_with_two_users_submitting(app):
+    assignment_id_1 = "assign_a"
+    assignment_id_2 = "b_assign"
+    course_id = "course_2"
+    notebook = "notebook"
+
+    # XXX: Doing this in a separate function doesn't work for some reason
+    #  (Exchange doesn't get called)
+    kwargs = {"data": {"notebooks": [notebook]}}
+    with patch.object(
+        BaseHandler, "get_current_user", return_value=user_kiz_instructor
+    ):
+        r = yield async_requests.post(
+            app.url
+            + f"/assignment?course_id={course_id}&assignment_id={assignment_id_1}",
+            files=files,
+            **kwargs,
+        )
+        r = yield async_requests.post(
+            app.url
+            + f"/assignment?course_id={course_id}&assignment_id={assignment_id_2}",
+            files=files,
+            **kwargs,
+        )
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+        r = yield async_requests.get(
+            app.url
+            + f"/assignment?course_id={course_id}&assignment_id={assignment_id_1}"
+        )
+    with patch.object(
+        BaseHandler, "get_current_user", return_value=user_brobbere_student
+    ):
+        r = yield async_requests.get(
+            app.url
+            + f"/assignment?course_id={course_id}&assignment_id={assignment_id_1}"
+        )
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+        r = yield async_requests.post(
+            app.url
+            + f"/submission?course_id={course_id}&assignment_id={assignment_id_1}",
+            files=files,
+        )
+    with patch.object(
+        BaseHandler, "get_current_user", return_value=user_brobbere_student
+    ):
+        r = yield async_requests.post(
+            app.url
+            + f"/submission?course_id={course_id}&assignment_id={assignment_id_1}",
+            files=files,
+        )
+    with patch.object(
+        BaseHandler, "get_current_user", return_value=user_kiz_instructor
+    ):
+        r = yield async_requests.get(
+            app.url
+            + f"/collections?course_id={course_id}&assignment_id={assignment_id_1}"
+        )
+
+    response_data = r.json()
+    print(f"{response_data}")
+    assert response_data["success"] is True
+    assert len(response_data["value"]) == 2
+
+
+# Reminder: actions are persistent, so the previous test set up most of the actions
+@pytest.mark.gen_test
+def test_collections_with_one_user_submits_2nd_time(app):
+    assignment_id_1 = "assign_a"
+    course_id = "course_2"
+    notebook = "notebook"
+
+    # XXX: Doing this in a separate function doesn't work for some reason
+    #  (Exchange doesn't get called)
+    kwargs = {"data": {"notebooks": [notebook]}}
+
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+        r = yield async_requests.post(
+            app.url
+            + f"/submission?course_id={course_id}&assignment_id={assignment_id_1}",
+            files=files,
+        )
+    with patch.object(
+        BaseHandler, "get_current_user", return_value=user_kiz_instructor
+    ):
+        r = yield async_requests.get(
+            app.url
+            + f"/collections?course_id={course_id}&assignment_id={assignment_id_1}"
+        )
+
+    response_data = r.json()
+    print(f"{response_data}")
+    assert response_data["success"] is True
+    assert len(response_data["value"]) == 3
+
+
+# Reminder: actions are persistent, so the previous test set up most of the actions
+@pytest.mark.gen_test
+def test_collections_with_named_user(app):
+    assignment_id_1 = "assign_a"
+    course_id = "course_2"
+    notebook = "notebook"
+    student = "1-kiz"
+
+    # XXX: Doing this in a separate function doesn't work for some reason
+    #  (Exchange doesn't get called)
+    kwargs = {"data": {"notebooks": [notebook]}}
+
+    with patch.object(
+        BaseHandler, "get_current_user", return_value=user_kiz_instructor
+    ):
+        r = yield async_requests.get(
+            app.url
+            + f"/collections?course_id={course_id}&assignment_id={assignment_id_1}&user_id={student}"
+        )
+
+    response_data = r.json()
+    print(f"{response_data}")
+    assert response_data["success"] is True
+    assert len(response_data["value"]) == 2

--- a/nbexchange/tests/test_handlers_fetch.py
+++ b/nbexchange/tests/test_handlers_fetch.py
@@ -307,8 +307,6 @@ def test_post_assignment16(app):
     assert "note" not in response_data  # just that it's missing
     paths = list(map(lambda assignment: assignment["path"], response_data["value"]))
     actions = list(map(lambda assignment: assignment["status"], response_data["value"]))
-    print(f"paths {paths}")
-    print(f"actions {actions}")
     assert len(paths) == 7  # 6
     assert actions == [
         "released",

--- a/nbexchange/tests/test_plugin_submit.py
+++ b/nbexchange/tests/test_plugin_submit.py
@@ -293,7 +293,6 @@ def test_submit_multiple_notebooks_in_assignment(plugin_config, tmpdir):
 
         def api_request(*args, **kwargs):
             if args[0].startswith("assignments"):
-                print("Returning mock api response")
                 return type(
                     "Request",
                     (object,),
@@ -331,7 +330,6 @@ def test_submit_multiple_notebooks_in_assignment(plugin_config, tmpdir):
                     },
                 )
             else:
-                print("checking for what's in the tarball")
                 pth = str(tmpdir.mkdir("submit_several").realpath())
                 assert args[0] == (
                     f"submission?course_id={course_id}&assignment_id={assignment_id3}"

--- a/nbexchange/tests/utils.py
+++ b/nbexchange/tests/utils.py
@@ -12,45 +12,45 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from urllib.parse import urljoin
 
-user_kiz = {"name": "1_kiz"}
-user_bert = {"name": "1_bert"}
+user_kiz = {"name": "1-kiz"}
+user_bert = {"name": "1-bert"}
 
 user_kiz_instructor = {
-    "name": "1_kiz",
+    "name": "1-kiz",
     "course_id": "course_2",
     "course_role": "Instructor",
     "course_title": "A title",
 }
 
 user_kiz_student = {
-    "name": "1_kiz",
+    "name": "1-kiz",
     "course_id": "course_2",
     "course_role": "Student",
     "course_title": "A title",
 }
 
 user_brobbere_instructor = {
-    "name": "1_brobbere",
+    "name": "1-brobbere",
     "course_id": "course_2",
     "course_role": "Instructor",
     "course_title": "A title",
 }
 
 user_brobbere_student = {
-    "name": "1_brobbere",
+    "name": "1-brobbere",
     "course_id": "course_2",
     "course_role": "Student",
 }
 
 user_lkihlman_instructor = {
-    "name": "1_lkihlman",
+    "name": "1-lkihlman",
     "course_id": "course_1",
     "course_role": "Instructor",
     "course_title": "A title",
 }
 
 user_lkihlman_student = {
-    "name": "1_lkihlman",
+    "name": "1-lkihlman",
     "course_id": "course_1",
     "course_role": "Student",
 }


### PR DESCRIPTION
Closes #39 

This adds support for the `--student` option in the command-line `collect` 

(`release-feedback` already seems to support it, thought there are no tests for it)