### PR TITLE
Fix missing message error:

### DIFF
--- a/nbexchange/plugin/collect.py
+++ b/nbexchange/plugin/collect.py
@@ -36,7 +36,10 @@ class ExchangeCollect(abc.ExchangeCollect, Exchange):
             with tarfile.open(fileobj=tar_file) as handle:
                 handle.extractall(path=dest_path)
         except Exception as e:  # TODO: exception handling
-            self.fail(e.message)
+            if hasattr(e, "message"):
+                self.fail(e.message)
+            else:
+                self.fail(e)
 
     def do_collect(self):
         """


### PR DESCRIPTION
Not all python exceptions have a message attribute, some don't. We were
getting errors in the logs that message wasn't part of some exceptions.