### PR TITLE
Replace noteable api request with jwt cookie check

### DIFF
--- a/nbexchange/handlers/auth/naas_user_handler.py
+++ b/nbexchange/handlers/auth/naas_user_handler.py
@@ -16,7 +16,9 @@ class NaasUserHandler(BaseUserHandler):
             cookies[name] = request.get_cookie(name)
 
         if "noteable_auth" not in cookies:
-            logging.debug(f"No noteable_auth cookie found - got {','.join(request.request.cookies)}")
+            logging.debug(
+                f"No noteable_auth cookie found - got {','.join(request.request.cookies)}"
+            )
             return None
 
         encoded = cookies["noteable_auth"]

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ REQUIRED = [
     "sqlalchemy==1.3.20",
     "nbgrader==0.7.0.dev0",
     "urllib3==1.25.11", # Pinned because of requests depdendency conflict
+    "pyjwt",
 ]
 
 # What packages are required for testing?


### PR DESCRIPTION
Instead of going back to Noteable to authorise the user, we can directly
check the jwt cookie to make sure it's valid. Just decoding the cookie
is enough to validate the time and hash etc.