### PR TITLE
Change the way fetch-feedback is logged

### DIFF
--- a/nbexchange/handlers/feedback.py
+++ b/nbexchange/handlers/feedback.py
@@ -105,13 +105,14 @@ class FeedbackHandler(BaseHandler):
                 f["checksum"] = r.checksum
                 feedbacks.append(f)
 
-            # Add action
-            action = nbexchange.models.actions.Action(
-                user_id=this_user["id"],
-                assignment_id=assignment.id,
-                action=nbexchange.models.actions.AssignmentActions.feedback_fetched,
-            )
-            session.add(action)
+                # Add action
+                action = nbexchange.models.actions.Action(
+                    user_id=this_user["id"],
+                    assignment_id=assignment.id,
+                    action=nbexchange.models.actions.AssignmentActions.feedback_fetched,
+                    location=r.location
+                )
+                session.add(action)
             self.finish({"success": True, "feedback": feedbacks})
 
     @authenticated

--- a/nbexchange/handlers/feedback.py
+++ b/nbexchange/handlers/feedback.py
@@ -110,7 +110,7 @@ class FeedbackHandler(BaseHandler):
                     user_id=this_user["id"],
                     assignment_id=assignment.id,
                     action=nbexchange.models.actions.AssignmentActions.feedback_fetched,
-                    location=r.location
+                    location=r.location,
                 )
                 session.add(action)
             self.finish({"success": True, "feedback": feedbacks})


### PR DESCRIPTION
The "fetch_feedback" handler in the exchange was
1. reporting every time it ran, rather than when it actually had files
2. didn't actually say what was being fetched.

This fixes both of those.

(Yes, it's perfectly possible for the call to run, and successfully report _zero_ items)