### PR TITLE
upgrade git to skip depreciation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.10
 
 ARG COMMIT=""
 LABEL commit=${COMMIT}
+RUN pip install --upgrade pip
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
It's a simple update.... just updates pip

Closes https://gitlab.edina.ac.uk/naas/nbexchange/-/issues/13