### PR TITLE
Nbgrader 0.8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     steps:
     - uses: actions/checkout@master
     - name: Setup Python ${{ matrix.python-version }} 

--- a/nbexchange/app.py
+++ b/nbexchange/app.py
@@ -141,6 +141,7 @@ class NbExchange(PrometheusMixIn, Application):
         See sqlalchemy.create_engine for details.
         """
     ).tag(config=True)
+
     upgrade_db = Bool(
         False,
         help="""Upgrade the database automatically on start.

--- a/nbexchange/models/__init__.py
+++ b/nbexchange/models/__init__.py
@@ -5,9 +5,10 @@ Notes:
     must be imported below the declaration for `Alembic`
     autogenerate to work.
 """
-import sqlalchemy.orm as orm
+# import sqlalchemy.orm as orm
+from sqlalchemy.orm import declarative_base
 
-Base = orm.declarative_base()
+Base = declarative_base()
 
 # E402 : module level import not at top of file
 # F401 : module imported but unused

--- a/nbexchange/models/__init__.py
+++ b/nbexchange/models/__init__.py
@@ -5,9 +5,9 @@ Notes:
     must be imported below the declaration for `Alembic`
     autogenerate to work.
 """
-from sqlalchemy.ext.declarative import declarative_base
+import sqlalchemy.orm as orm
 
-Base = declarative_base()
+Base = orm.declarative_base()
 
 # E402 : module level import not at top of file
 # F401 : module imported but unused

--- a/nbexchange/tests/test_smoketest.py
+++ b/nbexchange/tests/test_smoketest.py
@@ -1,6 +1,0 @@
-import socket
-
-
-def test_smoketest_nbexchange(container):
-    sock = socket.socket()
-    sock.connect(("127.0.0.1", container.ports["9000/tcp"][0]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ classifiers = [
 dependencies = [
   "alembic>=1.6.5",
   "jupyterhub>=1.4.1",
-  "nbgrader==0.8.2", # From pypi dated March 28th 2023
+  # "nbgrader==0.8.2", # From pypi dated March 28th 2023
+  "nbgrader==0.8.4", # From pypi dated 2023-06-16
   "psycopg2-binary>=2.8.6",
   "pyjwt<2",
   "sentry-sdk==1.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 
 # pyjwt limited due to djangorestframework-jwt dependencies
+# sqlalchemy spec is the same as nbgrader 0.8.4
 dependencies = [
   "alembic>=1.6.5",
   "jupyterhub>=1.4.1",
@@ -40,7 +41,7 @@ dependencies = [
   "psycopg2-binary>=2.8.6",
   "pyjwt<2",
   "sentry-sdk==1.14.0",
-  "sqlalchemy>=1.4.3",
+  "sqlalchemy>=1.4,<3",
   "tornado==6.1",
   "tornado-prometheus==0.1.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,16 +32,14 @@ classifiers = [
 ]
 
 # pyjwt limited due to djangorestframework-jwt dependencies
-# sqlalchemy spec is the same as nbgrader 0.8.4
+# sqlalchemy spec is whatever nbgrader uses!
 dependencies = [
   "alembic>=1.6.5",
   "jupyterhub>=1.4.1",
-  # "nbgrader==0.8.2", # From pypi dated March 28th 2023
-  "nbgrader==0.8.4", # From pypi dated 2023-06-16
+  "nbgrader==0.8.3", # 0.8.4 requires sqlalchemy 2, which breaks Jupyterhub
   "psycopg2-binary>=2.8.6",
   "pyjwt<2",
   "sentry-sdk==1.14.0",
-  "sqlalchemy>=1.4,<3",
   "tornado==6.1",
   "tornado-prometheus==0.1.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,15 +31,17 @@ classifiers = [
   "Intended Audience :: Education",
 ]
 
+# nbgrader 0.8.4 requires sqlalchemy 2, which breaks Jupyterhub
 # pyjwt limited due to djangorestframework-jwt dependencies
-# sqlalchemy spec is whatever nbgrader uses!
+# sqlalchemy spec is whatever nbgrader uses
 dependencies = [
   "alembic>=1.6.5",
   "jupyterhub>=1.4.1",
-  "nbgrader==0.8.3", # 0.8.4 requires sqlalchemy 2, which breaks Jupyterhub
+  "nbgrader==0.8.3",
   "psycopg2-binary>=2.8.6",
   "pyjwt<2",
   "sentry-sdk==1.14.0",
+  "sqlalchemy>=1.4,<3",
   "tornado==6.1",
   "tornado-prometheus==0.1.1",
 ]


### PR DESCRIPTION
NBGrader 0.8.3 is the latest version that works with EDINAs Notable service, so that's what's pinned here

(0.8.4 has pinned sqalchemy to an incompatible version for jupyterhub)

Closes #137 

Note: We need to create a release version once this is merged, to we can use it in noteable's notebooks