### PR TITLE
fix non-backward compatibility for feedback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install supervisor
 COPY supervisord.conf /usr/src/app
 
 # Copy package
-COPY pyproject.toml README.md /usr/src/app/
+COPY pyproject.toml README.md LICENSE /usr/src/app/
 COPY nbexchange /usr/src/app/nbexchange
 # Install dependencies
 RUN pip install .


### PR DESCRIPTION
The new code could not cope with submissions from notebooks running earlier versions of the code - in essence, as none of the timestamps aligned, no feedback was found.