### PR TITLE
Testing post data size limits

### DIFF
--- a/nbexchange/app.py
+++ b/nbexchange/app.py
@@ -320,9 +320,9 @@ Defaults to 'sqlite:///:memory:' (an in-memory SQLite database)
             return
         logging.info("app.start not a subapp")
 
-        # *NOT* adding 'max_buffer_size=self.max_buffer_size' here, as we handle the
-        # size-checks in code (both plugin & exchange side)
-        self.http_server = HTTPServer(self.tornado_application, xheaders=True)
+        # We need to set 'max_buffer_size=self.max_buffer_size' here, to avoid the default 100MB limnit
+        # we _also_ do size-checks in code (both plugin & exchange side)
+        self.http_server = HTTPServer(self.tornado_application, xheaders=True, max_buffer_size=self.max_buffer_size)
         self.http_server.listen(self.port, address=self.ip)
         logging.info("app.start about to hit the IOLoop start")
         if run_loop:

--- a/nbexchange/handlers/assignment.py
+++ b/nbexchange/handlers/assignment.py
@@ -249,14 +249,8 @@ class Assignment(BaseHandler):
     # This is releasing an **assignment**, not a student submission
     @authenticated
     def post(self):
-        # Do a content-length check, before we go any further
-        if "Content-Length" in self.request.headers and int(self.request.headers["Content-Length"]) > int(
-            self.max_buffer_size
-        ):
-            note = "File upload oversize, and rejected. Please reduce the contents of the assignment, re-generate, and re-release"  # noqa: E501
-            self.log.info(note)
-            self.finish({"success": False, "note": note})
-            return
+        # Reminder: the `max_buffer_size` we have set is in config is the size given to the underlying HTTPServer
+        # Oversized content is rejected by the underlying HTTPServer, and never gets here.
 
         [course_code, assignment_code] = self.get_params(["course_id", "assignment_id"])
         self.log.debug(

--- a/nbexchange/plugin/release_assignment.py
+++ b/nbexchange/plugin/release_assignment.py
@@ -83,6 +83,14 @@ class ExchangeReleaseAssignment(abc.ExchangeReleaseAssignment, Exchange):
 
         self.log.debug(f"Got back {r.status_code} after file upload")
 
+        # In theory, we should never hit this, as the file size _should_ be caught in `copy_files`
+        if r.status_code == 400 and sys.getsizeof(file) > self.max_buffer_size:
+            self.fail(
+                f"Assignment {self.coursedir.assignment_id} not released. "
+                "The contents of your assignment are too large:\n"
+                "You may have data files, temporary files, and/or working files that should not be included"
+                " - try deleting them."
+            )
         try:
             data = r.json()
         except json.decoder.JSONDecodeError as err:
@@ -99,10 +107,10 @@ class ExchangeReleaseAssignment(abc.ExchangeReleaseAssignment, Exchange):
         file = self.tar_source()
         if sys.getsizeof(file) > self.max_buffer_size:
             self.fail(
-                "Assignment {} not released. "
+                f"Assignment {self.coursedir.assignment_id} not released. "
                 "The contents of your assignment are too large:\n"
-                "You may have data files, temporary files, and/or working files that should not be included - try deleting them."  # noqa: E501
-                "".format(self.coursedir.assignment_id)
+                "You may have data files, temporary files, and/or working files that should not be included"
+                " - try deleting them."
             )
         # Upload files to exchange
         self.get_notebooks()

--- a/nbexchange/tests/test_handlers_release.py
+++ b/nbexchange/tests/test_handlers_release.py
@@ -224,20 +224,20 @@ def test_105MB_not_blocked(app, clear_database):  # noqa: F811
     shutil.rmtree(app.base_storage_location)
 
 
-# Note, the web HTTPServer just throws a 400 error for an oversized file
-# There is no way to catch/handle that _server side_
-@pytest.mark.gen_test
-def test_5point1GB_is_blocked__long_test(app, clear_database):  # noqa: F811
-    faked_tarball = create_any_tarball(5476083302)  # 5.1GB
-    faked_files = {"assignment": ("assignment.tar.gz", faked_tarball)}
-    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
-        r = yield async_requests.post(
-            app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
-            data={"notebooks": notebooks},
-            files=faked_files,
-        )
-    assert r.status_code == 400
-    assert r.content == b""
+# # Note, the web HTTPServer just throws a 400 error for an oversized file
+# # There is no way to catch/handle that _server side_
+# @pytest.mark.gen_test
+# def test_5point1GB_is_blocked__long_test(app, clear_database):  # noqa: F811
+#     faked_tarball = create_any_tarball(5476083302)  # 5.1GB
+#     faked_files = {"assignment": ("assignment.tar.gz", faked_tarball)}
+#     with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
+#         r = yield async_requests.post(
+#             app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
+#             data={"notebooks": notebooks},
+#             files=faked_files,
+#         )
+#     assert r.status_code == 400
+#     assert r.content == b""
 
 
 # fakes something going wrong in the "write to disk" code

--- a/nbexchange/tests/test_handlers_release.py
+++ b/nbexchange/tests/test_handlers_release.py
@@ -10,6 +10,7 @@ from nbexchange.handlers.base import BaseHandler
 from nbexchange.tests.utils import (  # noqa: F401 "clear_database"
     async_requests,
     clear_database,
+    create_any_tarball,
     get_files_dict,
     user_kiz,
     user_kiz_instructor,
@@ -207,7 +208,7 @@ def test_post_location_different_each_time(app, clear_database):  # noqa: F811
 
 
 @pytest.mark.gen_test
-def test_blocks_filesize(app, clear_database):  # noqa: F811
+def test_reducing_max_buffer_size_honoured(app, clear_database):  # noqa: F811
     with patch.object(BaseHandler, "max_buffer_size", return_value=int(50)):
         with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
             r = yield async_requests.post(
@@ -222,6 +223,25 @@ def test_blocks_filesize(app, clear_database):  # noqa: F811
         response_data["note"]
         == "File upload oversize, and rejected. Please reduce the contents of the assignment, re-generate, and re-release"  # noqa: E501 W503
     )
+
+
+# instructor can release
+@pytest.mark.gen_test
+def test_105MB_not_blocked(app, clear_database):  # noqa: F811
+    faked_tarball = create_any_tarball(104857600)  # 105MB
+    faked_files = {"assignment": ("assignment.tar.gz", faked_tarball)}
+
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
+        r = yield async_requests.post(
+            app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
+            data={"notebooks": notebooks},
+            files=faked_files,
+        )
+    assert r.status_code == 200
+    response_data = r.json()
+    assert response_data["success"] is True
+    assert response_data["note"] == "Released"
+    assert False
 
 
 # fakes something going wrong in the "write to disk" code

--- a/nbexchange/tests/test_handlers_submission.py
+++ b/nbexchange/tests/test_handlers_submission.py
@@ -8,6 +8,7 @@ from nbexchange.handlers.base import BaseHandler
 from nbexchange.tests.utils import (  # noqa: F401 "clear_database"
     async_requests,
     clear_database,
+    create_any_tarball,
     get_files_dict,
     user_kiz,
     user_kiz_instructor,
@@ -301,3 +302,51 @@ def test_post_submision_oversize_blocked(app, clear_database):  # noqa: F811
         response_data["note"]
         == "File upload oversize, and rejected. Please reduce the files in your submission and try again."  # noqa: E501 W503
     )
+
+
+@pytest.mark.gen_test
+def test_105MB_not_blocked(app, clear_database):  # noqa: F811
+    faked_tarball = create_any_tarball(104857600)  # 105MB
+    faked_files = {"assignment": ("assignment.tar.gz", faked_tarball)}
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
+        r = yield async_requests.post(
+            app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
+            files=release_files,
+        )
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+        r = yield async_requests.get(app.url + "/assignment?course_id=course_2&assignment_id=assign_a")
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+        params = "/submission?course_id=course_2&assignment_id=assign_a&timestamp=2020-01-01%2000%3A00%3A00.0%20UTC"
+        r = yield async_requests.post(
+            app.url + params,
+            files=faked_files,
+        )
+    assert r.status_code == 200
+    response_data = r.json()
+    assert response_data["success"] is True
+    assert response_data["note"] == "Submitted"
+    shutil.rmtree(app.base_storage_location)
+
+
+# Note, the web HTTPServer just throws a 400 error for an oversized file
+# There is no way to catch/handle that _server side_
+@pytest.mark.gen_test
+def test_5point1GB_is_blocked__long_test(app, clear_database):  # noqa: F811
+    faked_tarball = create_any_tarball(5476083302)  # 5.1GB
+    faked_files = {"assignment": ("assignment.tar.gz", faked_tarball)}
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
+        r = yield async_requests.post(
+            app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
+            files=release_files,
+        )
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+        r = yield async_requests.get(app.url + "/assignment?course_id=course_2&assignment_id=assign_a")
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+        params = "/submission?course_id=course_2&assignment_id=assign_a&timestamp=2020-01-01%2000%3A00%3A00.0%20UTC"
+        r = yield async_requests.post(
+            app.url + params,
+            files=faked_files,
+        )
+    assert r.status_code == 400
+    assert r.content == b""
+    shutil.rmtree(app.base_storage_location)

--- a/nbexchange/tests/test_handlers_submission.py
+++ b/nbexchange/tests/test_handlers_submission.py
@@ -328,25 +328,25 @@ def test_105MB_not_blocked(app, clear_database):  # noqa: F811
     shutil.rmtree(app.base_storage_location)
 
 
-# Note, the web HTTPServer just throws a 400 error for an oversized file
-# There is no way to catch/handle that _server side_
-@pytest.mark.gen_test
-def test_5point1GB_is_blocked__long_test(app, clear_database):  # noqa: F811
-    faked_tarball = create_any_tarball(5476083302)  # 5.1GB
-    faked_files = {"assignment": ("assignment.tar.gz", faked_tarball)}
-    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
-        r = yield async_requests.post(
-            app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
-            files=release_files,
-        )
-    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
-        r = yield async_requests.get(app.url + "/assignment?course_id=course_2&assignment_id=assign_a")
-    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
-        params = "/submission?course_id=course_2&assignment_id=assign_a&timestamp=2020-01-01%2000%3A00%3A00.0%20UTC"
-        r = yield async_requests.post(
-            app.url + params,
-            files=faked_files,
-        )
-    assert r.status_code == 400
-    assert r.content == b""
-    shutil.rmtree(app.base_storage_location)
+# # Note, the web HTTPServer just throws a 400 error for an oversized file
+# # There is no way to catch/handle that _server side_
+# @pytest.mark.gen_test
+# def test_5point1GB_is_blocked__long_test(app, clear_database):  # noqa: F811
+#     faked_tarball = create_any_tarball(5476083302)  # 5.1GB
+#     faked_files = {"assignment": ("assignment.tar.gz", faked_tarball)}
+#     with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
+#         r = yield async_requests.post(
+#             app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
+#             files=release_files,
+#         )
+#     with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+#         r = yield async_requests.get(app.url + "/assignment?course_id=course_2&assignment_id=assign_a")
+#     with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_student):
+#         params = "/submission?course_id=course_2&assignment_id=assign_a&timestamp=2020-01-01%2000%3A00%3A00.0%20UTC"
+#         r = yield async_requests.post(
+#             app.url + params,
+#             files=faked_files,
+#         )
+#     assert r.status_code == 400
+#     assert r.content == b""
+#     shutil.rmtree(app.base_storage_location)

--- a/nbexchange/tests/test_plugin_release_assignment.py
+++ b/nbexchange/tests/test_plugin_release_assignment.py
@@ -11,7 +11,7 @@ from nbgrader.exchange import ExchangeError
 from tornado import web
 
 from nbexchange.plugin import Exchange, ExchangeReleaseAssignment
-from nbexchange.tests.utils import get_feedback_file
+from nbexchange.tests.utils import create_any_tarball, get_feedback_file
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.ERROR)
@@ -280,7 +280,7 @@ def test_release_assignment_known_failure_from_exchange(plugin_config, tmpdir):
 
 
 @pytest.mark.gen_test
-def test_release_oversize_blocked(plugin_config, tmpdir):
+def test_release_reducing_max_buffer_size_honoured(plugin_config, tmpdir):
     plugin_config.CourseDirectory.root = "/"
 
     plugin_config.CourseDirectory.release_directory = str(tmpdir.mkdir(release_dir).realpath())
@@ -325,6 +325,94 @@ def test_release_oversize_blocked(plugin_config, tmpdir):
             str(e_info.value)
             == "Assignment assign_1 not released. The contents of your assignment are too large:\nYou may have data files, temporary files, and/or working files that should not be included - try deleting them."  # noqa: E501 W503
         )
+
+
+@pytest.mark.gen_test
+def test_release_105MB_not_blocked(plugin_config, tmpdir):
+    plugin_config.CourseDirectory.root = "/"
+
+    plugin_config.CourseDirectory.release_directory = str(tmpdir.mkdir(release_dir).realpath())
+    plugin_config.CourseDirectory.assignment_id = "assign_1"
+    os.makedirs(
+        os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1"),
+        exist_ok=True,
+    )
+    copyfile(
+        notebook1_filename,
+        os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1", "release.ipynb"),
+    )
+    with open(
+        os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1", "timestamp.txt"),
+        "w",
+    ) as fp:
+        fp.write("2020-01-01 00:00:00.0 UTC")
+
+    plugin = ExchangeReleaseAssignment(coursedir=CourseDirectory(config=plugin_config), config=plugin_config)
+
+    def api_request(*args, **kwargs):
+        assert args[0] == ("assignment?course_id=no_course&assignment_id=assign_1")
+        assert kwargs.get("method").lower() == "post"
+        assert kwargs.get("data").get("notebooks") == ["release"]
+        assert "assignment" in kwargs.get("files")
+        assert "assignment.tar.gz" == kwargs.get("files").get("assignment")[0]
+
+        return type(
+            "Request",
+            (object,),
+            {"status_code": 200, "json": (lambda: {"success": True})},
+        )
+
+    with patch.object(Exchange, "api_request", side_effect=api_request):
+        with patch.object(ExchangeReleaseAssignment, "tar_source", return_value=create_any_tarball(110100480)):  # 105MB
+            plugin.start()
+    assert True  # No failure
+
+
+# @pytest.mark.gen_test
+def test_release_5point1GB_is_blocked__long_test(plugin_config, tmpdir):
+    plugin_config.CourseDirectory.root = "/"
+
+    plugin_config.CourseDirectory.release_directory = str(tmpdir.mkdir(release_dir).realpath())
+    plugin_config.CourseDirectory.assignment_id = "assign_1"
+    os.makedirs(
+        os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1"),
+        exist_ok=True,
+    )
+    copyfile(
+        notebook1_filename,
+        os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1", "release.ipynb"),
+    )
+    with open(
+        os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1", "timestamp.txt"),
+        "w",
+    ) as fp:
+        fp.write("2020-01-01 00:00:00.0 UTC")
+
+    plugin = ExchangeReleaseAssignment(coursedir=CourseDirectory(config=plugin_config), config=plugin_config)
+
+    def api_request(*args, **kwargs):
+        assert args[0] == ("assignment?course_id=no_course&assignment_id=assign_1")
+        assert kwargs.get("method").lower() == "post"
+        assert kwargs.get("data").get("notebooks") == ["release"]
+        assert "assignment" in kwargs.get("files")
+        assert "assignment.tar.gz" == kwargs.get("files").get("assignment")[0]
+
+        return type(
+            "Request",
+            (object,),
+            {"status_code": 200, "json": (lambda: {"success": True})},
+        )
+
+    with patch.object(Exchange, "api_request", side_effect=api_request):
+        with patch.object(
+            ExchangeReleaseAssignment, "tar_source", return_value=create_any_tarball(5476083302)  # 5.1GB
+        ):
+            with pytest.raises(ExchangeError) as e_info:
+                plugin.start()
+            assert (
+                str(e_info.value)
+                == "Assignment assign_1 not released. The contents of your assignment are too large:\nYou may have data files, temporary files, and/or working files that should not be included - try deleting them."  # noqa: E501 W503
+            )
 
 
 @pytest.mark.gen_test

--- a/nbexchange/tests/test_plugin_release_assignment.py
+++ b/nbexchange/tests/test_plugin_release_assignment.py
@@ -378,30 +378,11 @@ def test_release_5point1GB_is_blocked__long_test(plugin_config, tmpdir):
         os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1"),
         exist_ok=True,
     )
-    copyfile(
-        notebook1_filename,
-        os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1", "release.ipynb"),
-    )
-    with open(
-        os.path.join(plugin_config.CourseDirectory.release_directory, "assign_1", "timestamp.txt"),
-        "w",
-    ) as fp:
-        fp.write("2020-01-01 00:00:00.0 UTC")
 
     plugin = ExchangeReleaseAssignment(coursedir=CourseDirectory(config=plugin_config), config=plugin_config)
 
     def api_request(*args, **kwargs):
-        assert args[0] == ("assignment?course_id=no_course&assignment_id=assign_1")
-        assert kwargs.get("method").lower() == "post"
-        assert kwargs.get("data").get("notebooks") == ["release"]
-        assert "assignment" in kwargs.get("files")
-        assert "assignment.tar.gz" == kwargs.get("files").get("assignment")[0]
-
-        return type(
-            "Request",
-            (object,),
-            {"status_code": 200, "json": (lambda: {"success": True})},
-        )
+        raise web.HTTPError(status_code=400, log_message="Bad Request")
 
     with patch.object(Exchange, "api_request", side_effect=api_request):
         with patch.object(

--- a/nbexchange/tests/test_plugin_submit.py
+++ b/nbexchange/tests/test_plugin_submit.py
@@ -14,7 +14,7 @@ from nbgrader.coursedir import CourseDirectory
 from nbgrader.exchange import ExchangeError
 
 from nbexchange.plugin import Exchange, ExchangeSubmit
-from nbexchange.tests.utils import get_feedback_file
+from nbexchange.tests.utils import create_any_tarball, get_feedback_file
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.ERROR)
@@ -1641,7 +1641,7 @@ def test_submit_with_multiple_assignments_oldest_first(plugin_config, tmpdir):
 
 # Check the client-side oversizxe limit works
 @pytest.mark.gen_test
-def test_submit_fails_oversize(plugin_config, tmpdir):
+def test_submit_reducing_max_buffer_size_honoured(plugin_config, tmpdir):
     try:
         plugin_config.CourseDirectory.course_id = course_id
         plugin_config.CourseDirectory.assignment_id = assignment_id1
@@ -1715,6 +1715,160 @@ def test_submit_fails_oversize(plugin_config, tmpdir):
                 str(e_info.value)
                 == "Assignment assign_1_1 not submitted. The contents of your submission are too large:\nYou may have data files, temporary files, and/or working files that are not needed - try deleting them."  # noqa: E501 W503
             )
+
+    finally:
+        shutil.rmtree(assignment_id1)
+
+
+@pytest.mark.gen_test
+def test_release_105MB_not_blocked(plugin_config, tmpdir):
+    try:
+        plugin_config.CourseDirectory.course_id = course_id
+        plugin_config.CourseDirectory.assignment_id = assignment_id1
+
+        os.makedirs(assignment_id1, exist_ok=True)
+        copyfile(
+            notebook1_filename,
+            os.path.join(assignment_id1, basename(notebook1_filename)),
+        )
+
+        plugin = ExchangeSubmit(coursedir=CourseDirectory(config=plugin_config), config=plugin_config)
+
+        def api_request(*args, **kwargs):
+            if args[0].startswith("assignments"):
+                return type(
+                    "Request",
+                    (object,),
+                    {
+                        "status_code": 200,
+                        "json": (
+                            lambda: {
+                                "success": True,
+                                "value": [
+                                    {
+                                        "assignment_id": assignment_id1,
+                                        "student_id": "1",
+                                        "course_id": course_id,
+                                        "status": "released",
+                                        "path": "",
+                                        "notebooks": [
+                                            {
+                                                "notebook_id": "assignment-0.6",
+                                                "has_exchange_feedback": False,
+                                                "feedback_updated": False,
+                                                "feedback_timestamp": False,
+                                            }
+                                        ],
+                                        "timestamp": "2020-01-01 00:00:00.000000 UTC",
+                                    }
+                                ],
+                            }
+                        ),
+                    },
+                )
+            else:
+
+                assert args[0].startswith(f"submission?course_id={course_id}&assignment_id={assignment_id1}&timestamp=")
+                assert "method" not in kwargs or kwargs.get("method").lower() == "post"
+                files = kwargs.get("files")
+                assert "assignment" in files
+                assert "assignment.tar.gz" == files["assignment"][0]
+
+                return type(
+                    "Request",
+                    (object,),
+                    {"status_code": 200, "json": (lambda: {"success": True})},
+                )
+
+        with patch.object(Exchange, "api_request", side_effect=api_request):
+            with patch.object(
+                ExchangeSubmit,
+                "tar_source",
+                return_value=(create_any_tarball(110100480), "2020-01-01 00:00:00.000000 UTC"),  # 105MB
+            ):
+                plugin.start()
+        assert True  # No failure
+
+    finally:
+        shutil.rmtree(assignment_id1)
+
+
+# @pytest.mark.gen_test
+def test_release_5point1GB_is_blocked__long_test(plugin_config, tmpdir):
+    try:
+        plugin_config.CourseDirectory.course_id = course_id
+        plugin_config.CourseDirectory.assignment_id = assignment_id1
+
+        os.makedirs(assignment_id1, exist_ok=True)
+        copyfile(
+            notebook1_filename,
+            os.path.join(assignment_id1, basename(notebook1_filename)),
+        )
+
+        plugin = ExchangeSubmit(coursedir=CourseDirectory(config=plugin_config), config=plugin_config)
+
+        def api_request(*args, **kwargs):
+            if args[0].startswith("assignments"):
+                return type(
+                    "Request",
+                    (object,),
+                    {
+                        "status_code": 200,
+                        "json": (
+                            lambda: {
+                                "success": True,
+                                "value": [
+                                    {
+                                        "assignment_id": assignment_id1,
+                                        "student_id": "1",
+                                        "course_id": course_id,
+                                        "status": "released",
+                                        "path": "",
+                                        "notebooks": [
+                                            {
+                                                "notebook_id": "assignment-0.6",
+                                                "has_exchange_feedback": False,
+                                                "feedback_updated": False,
+                                                "feedback_timestamp": False,
+                                            }
+                                        ],
+                                        "timestamp": "2020-01-01 00:00:00.000000 UTC",
+                                    }
+                                ],
+                            }
+                        ),
+                    },
+                )
+            else:
+                pth = str(tmpdir.mkdir("submit_several").realpath())
+
+                assert args[0].startswith(f"submission?course_id={course_id}&assignment_id={assignment_id1}&timestamp=")
+                assert "method" not in kwargs or kwargs.get("method").lower() == "post"
+                files = kwargs.get("files")
+                assert "assignment" in files
+                assert "assignment.tar.gz" == files["assignment"][0]
+                tar_file = io.BytesIO(files["assignment"][1])
+                with tarfile.open(fileobj=tar_file) as handle:
+                    handle.extractall(path=pth)
+
+                return type(
+                    "Request",
+                    (object,),
+                    {"status_code": 200, "json": (lambda: {"success": True})},
+                )
+
+        with patch.object(Exchange, "api_request", side_effect=api_request):
+            with patch.object(
+                ExchangeSubmit,
+                "tar_source",
+                return_value=(create_any_tarball(5476083302), "2020-01-01 00:00:00.000000 UTC"),  # 5.1GB
+            ):
+                with pytest.raises(ExchangeError) as e_info:
+                    plugin.start()
+                assert (
+                    str(e_info.value)
+                    == "Assignment assign_1_1 not submitted. The contents of your submission are too large:\nYou may have data files, temporary files, and/or working files that are not needed - try deleting them."  # noqa: E501 W503
+                )
 
     finally:
         shutil.rmtree(assignment_id1)

--- a/nbexchange/tests/utils.py
+++ b/nbexchange/tests/utils.py
@@ -268,6 +268,27 @@ def get_feedback_file(filename):
     return files
 
 
+# Another method created by ELM - does this make me a lazy programmer?
+def create_any_tarball(target_size_bytes=int(1e9)):  # Default size set to about 1GB
+    data = os.urandom(target_size_bytes)
+    tar_file = io.BytesIO()
+
+    with tarfile.open(fileobj=tar_file, mode="w:gz") as tar_handle:
+
+        with closing(io.BytesIO(data)) as fobj:
+            tarinfo = tarfile.TarInfo("filler.bin")
+            tarinfo.size = len(fobj.getvalue())
+            tarinfo.mtime = time.time()
+            tar_handle.addfile(tarinfo, fileobj=fobj)
+
+    tar_file.seek(0)
+
+    # To check the file size, uncomment the next line
+    print(f"Created Tarball Size: {len(tar_file.getvalue())} bytes")
+
+    return tar_file.read()
+
+
 class _AsyncRequests:
     """Wrapper around requests to return a Future from request methods
     A single thread is allocated to avoid blocking the IOLoop thread.

--- a/nbexchange/tests/utils.py
+++ b/nbexchange/tests/utils.py
@@ -283,9 +283,6 @@ def create_any_tarball(target_size_bytes=int(1e9)):  # Default size set to about
 
     tar_file.seek(0)
 
-    # To check the file size, uncomment the next line
-    print(f"Created Tarball Size: {len(tar_file.getvalue())} bytes")
-
     return tar_file.read()
 
 


### PR DESCRIPTION
Adds tests for actual large tarball uploads.

The tests did actually show that there _was_ a limit we were unaware of, which has been fixed.

Note that we need to "skip" the 5.1G handler tests for github `actions`