### PR TITLE
38 update gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,28 +1,31 @@
-variables:
-  VERSION: $CI_PIPELINE_ID-$CI_COMMIT_REF_SLUG
+# This file is specific to the EDINA in-house gitlab repo... where we internally
+# build & distribute our instance of the service
+include:
+  - project: "naas/Group-issues"
+    file: "/common-templates.yml"
 
-image: registry.gitlab.edina.ac.uk:1875/shared/gitlab-ci-tools
+variables:
+  IMAGE_NAME: $CI_REGISTRY_IMAGE # Needs to match production.yml
+  LOCATION: "."
 
 stages:
   - build
-  - publish
+  - release-branch
+  - release-master
+  - delete
 
-build:
-  stage: build
-  script:
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-    - docker-compose build
-    - docker tag edina/nbexchange:$VERSION $CI_REGISTRY_IMAGE:$VERSION
-    - docker push $CI_REGISTRY_IMAGE:$VERSION
 
-publish-python:
-  stage: publish
-  variables:
-    FLIT_INDEX_URL: https://gitlab.edina.ac.uk/api/v4/projects/${CI_PROJECT_ID}/packages/pypi
-  script:
-    - pip install flit
-    - flit build
-    - FLIT_PASSWORD=${CI_JOB_TOKEN} FLIT_USERNAME=gitlab-ci-token flit publish
-  only:
-    - tags
+# master branch builds CI-SLUG & latest
+build-app:
+  extends: .build-template
+
+# working branch only builds C_-SLUG
+release-branch:
+  extends: .release-branch-template
+
+release-master:
+  extends: .release-master-template
+
+delete-image:
+  extends: .delete-template
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ stages:
   - release-master
   - delete
 
+## There is no test stage here: testing is run on github
 
 # master branch builds CI-SLUG & latest
 build-app:


### PR DESCRIPTION
Removes the thing that keeps failing in edina's gitlab: the job that was supposed to export a built docker image to a hub somewhere off-site

This PR also does two two things:
1. It separates the _build_ from the _release_ - which then allows us to auto-release `master` & allow a manual release of development branches
2. It allows us to use the standard build process we have set up for the other components using the EDINA Gitlab-CI processes