### PR TITLE
DRAFT: Abstract out the connection authentication in the plugin code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A dockerised service that replaces the defaukt nbgrader Exchange.
   - [Configuring the `nbexchange` service](#configuring-the-nbexchange-service)
     - [**`user_plugin_class`** revisited](#user_plugin_class-revisited)
   - [Configuring `nbgrader` to use the alternative exchange in Jupyterlab/Jupyter-Notebook](#configuring-nbgrader-to-use-the-alternative-exchange-in-jupyterlabjupyter-notebook)
+    - [Confuguring the NbExchange plugins to talk to the NbExchange server](#confuguring-the-nbexchange-plugins-to-talk-to-the-nbexchange-server)
 - [Contributing](#contributing)
   - [Releasing new versions](#releasing-new-versions)
 
@@ -59,6 +60,7 @@ This exchange has some assumptions because of the environment required it.
 There are the following assumptions:
 
 - You have an API for authenticating users who connect to the exchange (possibly Jupyterhub, but not always)
+  - In our service, we use a JSON Web Token for this
 - Usernames will be unique across the whole system 
 - Internal storage is in two parts:
   - An sql database for metadata, and
@@ -228,6 +230,37 @@ These plugins will also check the size of _releases_ & _submissions_
 
 By default, upload sizes are limited to 5GB (5253530000)
 The figure is bytes
+
+### Confuguring the NbExchange plugins to talk to the NbExchange server
+
+The plugins make http requests to the server, which requires it to prepare several things:
+
+- `base_service_url` is the `http origin` of the NbExchange service - we default this to `https://noteable.edina.ac.uk`, 'cos.... _advertising_
+- `base_path` is the path-part of requests into the exchange. This needs to match `base_url` defined in the NbExchange service, and (likewise) defaults to `/services/nbexchange/`.
+- `api_plugin_class` is the name of the class [which has subclassed `nbexchange.plugin.exchange.BaseApiPlugin`] (see `DefaultApiPlugin` in the same file, and the `test_plugin_exchange_with_bespoke_apiPlugin.py` test file.)
+
+eg:
+
+
+
+
+```python
+from nbexchange.plugin import BaseApiPlugin
+
+class JWTApiPlugin(BaseApiPlugin):
+    def prep_api_call(self, path):
+        jwt_token = os.environ.get("DEMO_JWT")
+        cookies = dict()
+        headers = dict()
+
+        if jwt_token:
+            cookies["demo_auth"] = jwt_token
+
+        url = self.service_url() + path
+        return url, cookies, headers
+        
+c.ExchangeFactory.Exchange.api_plugin_class = JWTApiPlugin
+```
 
 # Contributing
 

--- a/nbexchange/plugin/__init__.py
+++ b/nbexchange/plugin/__init__.py
@@ -9,7 +9,7 @@ in your root `nbgrader_config.py` file.
 """
 
 from .collect import ExchangeCollect
-from .exchange import Exchange, ExchangeError
+from .exchange import BaseApiPlugin, Exchange, ExchangeError
 from .fetch import ExchangeFetch
 from .fetch_assignment import ExchangeFetchAssignment
 from .fetch_feedback import ExchangeFetchFeedback
@@ -20,6 +20,7 @@ from .release_feedback import ExchangeReleaseFeedback
 from .submit import ExchangeSubmit
 
 __all__ = [
+    "BaseApiPlugin",
     "Exchange",
     "ExchangeError",
     "ExchangeCollect",

--- a/nbexchange/plugin/exchange.py
+++ b/nbexchange/plugin/exchange.py
@@ -1,6 +1,7 @@
 import fnmatch
 import glob
 import os
+from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import partial
 from textwrap import dedent
@@ -8,17 +9,50 @@ from urllib.parse import urljoin
 from zoneinfo import ZoneInfo
 
 import requests
-from nbgrader.auth import Authenticator
 from nbgrader.exchange import ExchangeError
 from nbgrader.exchange.abc import Exchange as ABCExchange
-from traitlets import Bool, Integer, Unicode
+from traitlets import Bool, Integer, Type, Unicode
 
 
-class MockAuthenticator(Authenticator):
-    super(Authenticator)
+class BaseApiPlugin(ABC):
+    @abstractmethod
+    def prep_api_call(self, path: str) -> dict:
+        """
+        Sets up the url, any cookies, and any headers needed by the jupyterlab plugins
+        to call the NBExchange service.
 
-    def api_request(self, path, method="GET", *args, **kwargs):
+        This allows implimentors to create their own methods for creating authenticated
+        connections between the notebook plugins and the NBExchange service
+
+        :param path: The path for the request being made: path-part + parameters
+        :return: the url, cookies, and headers to use in the api_request call
+        """
         pass
+
+
+class DefaultApiPlugin(BaseApiPlugin):
+
+    def prep_api_call(self, path):
+        self.log.warning("The plugins are using the default prep_api_call. This is probably wrong.")
+
+        url = self.service_url() + path
+        cookies = dict()
+        headers = dict()
+
+        return url, cookies, headers
+
+
+class NaasApiPlugin(BaseApiPlugin):
+    def prep_api_call(self, path):
+        jwt_token = os.environ.get("NAAS_JWT")
+        cookies = dict()
+        headers = dict()
+
+        if jwt_token:
+            cookies["noteable_auth"] = jwt_token
+
+        url = self.service_url() + path
+        return url, cookies, headers
 
 
 class Exchange(ABCExchange):
@@ -46,9 +80,17 @@ class Exchange(ABCExchange):
     ).tag(config=True)
 
     base_service_url = Unicode(os.environ.get("NAAS_BASE_URL", "https://noteable.edina.ac.uk")).tag(config=True)
+    base_path = Unicode(
+        "/services/nbexchange/",
+        help="""
+Base path for api queries into the exchange - should match 'base_url' in the NbExchange App configuration.
+Defaults to '/services/nbexchange/'
+""",
+        config=True,
+    )
 
     def service_url(self):
-        this_url = urljoin(self.base_service_url, "/services/nbexchange/")
+        this_url = urljoin(self.base_service_url, self.base_path)
         self.log.debug(f"service_url: {this_url}")
         return this_url
 
@@ -64,6 +106,13 @@ class Exchange(ABCExchange):
         config=True,
     )
 
+    api_plugin_class = Type(
+        DefaultApiPlugin,
+        klass=BaseApiPlugin,
+        config=True,
+        help="The class to use for prepping connections to the exchange",
+    )
+
     def check_timezone(self, value: datetime) -> datetime:
         if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
             value = value.replace(tzinfo=ZoneInfo(self.timezone))
@@ -73,15 +122,12 @@ class Exchange(ABCExchange):
         self.log.fatal(msg)
         raise ExchangeError(msg)
 
+    def prep_api_call(self, path):
+        return self.api_plugin_class.prep_api_call(self, path)
+
     def api_request(self, path, method="GET", *args, **kwargs):
-        jwt_token = os.environ.get("NAAS_JWT")
-        cookies = dict()
-        headers = dict()
 
-        if jwt_token:
-            cookies["noteable_auth"] = jwt_token
-
-        url = self.service_url() + path
+        url, cookies, headers = self.prep_api_call(path)
 
         self.log.debug(f"Exchange.api_request calling exchange with url {url}")
 

--- a/nbexchange/tests/test_plugin_exchange.py
+++ b/nbexchange/tests/test_plugin_exchange.py
@@ -69,21 +69,13 @@ def test_exhange_api_request_post():
 
     def asserts(*args, **kwargs):
         assert "cookies" in kwargs
-        assert "noteable_auth" in kwargs["cookies"]
-        assert kwargs["cookies"]["noteable_auth"] == "test_token"
         assert "headers" in kwargs
         assert args[0] == plugin.service_url() + "test"
         return "Success"
 
-    naas_token = os.environ.get("NAAS_JWT")
-    os.environ["NAAS_JWT"] = "test_token"
     with patch("nbexchange.plugin.exchange.requests.post", side_effect=asserts):
         called = plugin.api_request("test", method="POST")
         assert called == "Success"
-    if naas_token is not None:
-        os.environ["NAAS_JWT"] = naas_token
-    else:
-        del os.environ["NAAS_JWT"]
 
 
 @pytest.mark.gen_test
@@ -92,21 +84,13 @@ def test_exhange_api_request_delete():
 
     def asserts(*args, **kwargs):
         assert "cookies" in kwargs
-        assert "noteable_auth" in kwargs["cookies"]
-        assert kwargs["cookies"]["noteable_auth"] == "test_token"
         assert "headers" in kwargs
         assert args[0] == plugin.service_url() + "test"
         return "Success"
 
-    naas_token = os.environ.get("NAAS_JWT")
-    os.environ["NAAS_JWT"] = "test_token"
     with patch("nbexchange.plugin.exchange.requests.delete", side_effect=asserts):
         called = plugin.api_request("test", method="DELETE")
         assert called == "Success"
-    if naas_token is not None:
-        os.environ["NAAS_JWT"] = naas_token
-    else:
-        del os.environ["NAAS_JWT"]
 
 
 @pytest.mark.gen_test
@@ -115,21 +99,13 @@ def test_exhange_api_request_get():
 
     def asserts(*args, **kwargs):
         assert "cookies" in kwargs
-        assert "noteable_auth" in kwargs["cookies"]
-        assert kwargs["cookies"]["noteable_auth"] == "test_token"
         assert "headers" in kwargs
         assert args[0] == plugin.service_url() + "test"
         return "Success"
 
-    naas_token = os.environ.get("NAAS_JWT")
-    os.environ["NAAS_JWT"] = "test_token"
     with patch("nbexchange.plugin.exchange.requests.get", side_effect=asserts):
         called = plugin.api_request("test")
         assert called == "Success"
-    if naas_token is not None:
-        os.environ["NAAS_JWT"] = naas_token
-    else:
-        del os.environ["NAAS_JWT"]
 
 
 @pytest.mark.gen_test
@@ -137,15 +113,10 @@ def test_exhange_api_request_get_timeout():
     plugin = Exchange()
 
     plugin.api_timeout = 2
-    naas_token = os.environ.get("NAAS_JWT")
-    os.environ["NAAS_JWT"] = "test_token"
+
     with patch("nbexchange.plugin.exchange.requests.get", side_effect=requests.exceptions.Timeout):
         with pytest.raises(requests.exceptions.Timeout):
             plugin.api_request("test")
-    if naas_token is not None:
-        os.environ["NAAS_JWT"] = naas_token
-    else:
-        del os.environ["NAAS_JWT"]
 
 
 @pytest.mark.gen_test

--- a/nbexchange/tests/test_plugin_exchange_with_bespoke_apiPlugin.py
+++ b/nbexchange/tests/test_plugin_exchange_with_bespoke_apiPlugin.py
@@ -1,0 +1,102 @@
+import logging
+import os
+
+import pytest
+from mock import patch
+
+from nbexchange.plugin import BaseApiPlugin, Exchange
+
+logger = logging.getLogger(__file__)
+logger.setLevel(logging.ERROR)
+
+"""
+In this module we check that various helper methods in the Exchange base class works as expected.
+In particular, we're checking that the api_request method does the right thing, as we will
+be mocking it when testing the other classes.
+"""
+
+
+class JWTApiPlugin(BaseApiPlugin):
+    def prep_api_call(self, path: str = None):
+        jwt_token = os.environ.get("DEMO_JWT")
+        cookies = dict()
+        headers = dict()
+
+        if jwt_token:
+            cookies["demo_auth"] = jwt_token
+
+        url = self.service_url() + path
+        return url, cookies, headers
+
+
+@pytest.mark.gen_test
+def test_exhange_api_request_post():
+
+    plugin = Exchange()
+    plugin.api_plugin_class = JWTApiPlugin
+
+    def asserts(*args, **kwargs):
+        assert "cookies" in kwargs
+        assert "demo_auth" in kwargs["cookies"]
+        assert kwargs["cookies"]["demo_auth"] == "test_token"
+        assert "headers" in kwargs
+        assert args[0] == plugin.service_url() + "test"
+        return "Success"
+
+    naas_token = os.environ.get("DEMO_JWT")
+    os.environ["DEMO_JWT"] = "test_token"
+    with patch("nbexchange.plugin.exchange.requests.post", side_effect=asserts):
+        called = plugin.api_request("test", method="POST")
+        assert called == "Success"
+    if naas_token is not None:
+        os.environ["DEMO_JWT"] = naas_token
+    else:
+        del os.environ["DEMO_JWT"]
+
+
+@pytest.mark.gen_test
+def test_exhange_api_request_delete():
+    plugin = Exchange()
+    plugin.api_plugin_class = JWTApiPlugin
+
+    def asserts(*args, **kwargs):
+        assert "cookies" in kwargs
+        assert "demo_auth" in kwargs["cookies"]
+        assert kwargs["cookies"]["demo_auth"] == "test_token"
+        assert "headers" in kwargs
+        assert args[0] == plugin.service_url() + "test"
+        return "Success"
+
+    naas_token = os.environ.get("DEMO_JWT")
+    os.environ["DEMO_JWT"] = "test_token"
+    with patch("nbexchange.plugin.exchange.requests.delete", side_effect=asserts):
+        called = plugin.api_request("test", method="DELETE")
+        assert called == "Success"
+    if naas_token is not None:
+        os.environ["DEMO_JWT"] = naas_token
+    else:
+        del os.environ["DEMO_JWT"]
+
+
+@pytest.mark.gen_test
+def test_exhange_api_request_get():
+    plugin = Exchange()
+    plugin.api_plugin_class = JWTApiPlugin
+
+    def asserts(*args, **kwargs):
+        assert "cookies" in kwargs
+        assert "demo_auth" in kwargs["cookies"]
+        assert kwargs["cookies"]["demo_auth"] == "test_token"
+        assert "headers" in kwargs
+        assert args[0] == plugin.service_url() + "test"
+        return "Success"
+
+    naas_token = os.environ.get("DEMO_JWT")
+    os.environ["DEMO_JWT"] = "test_token"
+    with patch("nbexchange.plugin.exchange.requests.get", side_effect=asserts):
+        called = plugin.api_request("test")
+        assert called == "Success"
+    if naas_token is not None:
+        os.environ["DEMO_JWT"] = naas_token
+    else:
+        del os.environ["DEMO_JWT"]


### PR DESCRIPTION
The original nbExchange plugins were hard-wired to use JWTs to identify the user and to pass information for the NbExchange server - this is fine for Noteable, but other users may (definitely do) use different methods .... see #172 