### PR TITLE
Normalise history params

### DIFF
--- a/nbexchange/handlers/history.py
+++ b/nbexchange/handlers/history.py
@@ -20,8 +20,11 @@ This relys on users being logged in, and the user-object having additional data:
 class History(BaseHandler):
     """.../actions/
     parmas:
-        course_id: course_code - optional
+        action: action string - optional. If provided, only returns actions of this type.
+        course_id: course code string - optional
+        course_code: course code string - optional. Depreciated.
 
+    "action string" must be one of the values in nbexchange.models.actions.AssignmentActions
 
     GET: gets list of actions relevent to the user.
 
@@ -83,7 +86,14 @@ class History(BaseHandler):
 
         models = {}
 
-        [action_param, course_code_param] = self.get_params(["action", "course_code"])
+        [action_param, course_id_param, course_code_param] = self.get_params(["action", "course_id", "course_code"])
+        self.log.info("History called")
+        if course_code_param:
+            self.log.info(
+                "History: course_code parameter is deprecated and will be removed in a future release. Please use course_id instead."  # noqa: E501
+            )
+        if course_code_param and not course_id_param:
+            course_id_param = course_code_param
 
         # Python 3.12 required to do "str" in Enum so use __members__ instead
         if action_param and action_param not in AssignmentActions.__members__:
@@ -99,9 +109,9 @@ class History(BaseHandler):
         # Find all the course_codes this user should be able to see
         with scoped_session() as session:
             subscriptions_query = session.query(nbexchange.models.Subscription).filter_by(user_id=this_user["id"])
-            if course_code_param:
+            if course_id_param:
                 subscriptions_query = subscriptions_query.filter(
-                    nbexchange.models.Subscription.course.has(course_code=course_code_param)
+                    nbexchange.models.Subscription.course.has(course_code=course_id_param)
                 )
 
             subscriptions = subscriptions_query.all()

--- a/nbexchange/tests/test_handlers_history.py
+++ b/nbexchange/tests/test_handlers_history.py
@@ -268,6 +268,56 @@ def test_history_actions_filtered_by_course(app, clear_database):  # noqa: F811
         )
 
     with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
+        r = yield async_requests.get(app.url + "/history?course_id=course_2b")
+    assert r.status_code == 200
+    response_data = r.json()
+    assert response_data["success"] is True
+    assert "value" in response_data
+    assert response_data["value"] == [
+        {
+            "role": {"Instructor": 1},
+            "user_id": {"1": 1},
+            "assignments": [
+                {
+                    "assignment_id": 2,
+                    "assignment_code": "assign_a2",
+                    "actions": [
+                        {
+                            "action": "AssignmentActions.released",
+                            "path": ANY,
+                            "timestamp": ANY,
+                            "user": "1-kiz",
+                        }
+                    ],
+                    "action_summary": {"released": 1},
+                }
+            ],
+            "isInstructor": True,
+            "course_id": 2,
+            "course_code": "course_2b",
+            "course_title": "A title",
+        },
+    ]
+    shutil.rmtree(app.base_storage_location)
+
+
+# as above, but using the depreciated "course_code" param instead of "course_id" - should work the same
+@pytest.mark.gen_test
+def test_history_actions_filtered_by_course_depreciated_code_param(app, clear_database):  # noqa: F811
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
+        r = yield async_requests.post(
+            app.url + "/assignment?course_id=course_2&assignment_id=assign_a",
+            files=release_files,
+        )
+    user_kiz2_instructor = dict(user_kiz_instructor)  # duplicate, not reference
+    user_kiz2_instructor["course_id"] = "course_2b"
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz2_instructor):
+        r = yield async_requests.post(
+            app.url + "/assignment?course_id=course_2b&assignment_id=assign_a2",
+            files=release_files,
+        )
+
+    with patch.object(BaseHandler, "get_current_user", return_value=user_kiz_instructor):
         r = yield async_requests.get(app.url + "/history?course_code=course_2b")
     assert r.status_code == 200
     response_data = r.json()

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "enabled": false
 }


### PR DESCRIPTION
Adds `course_id` to the history api call, and marks `course_code` as depreciated - this makes the update a _non-breaking_ update

closes #254 

(also switches off `renovate` as it does terrible things to our internal mirror of the code)